### PR TITLE
Improved -target and -v options

### DIFF
--- a/c.bas
+++ b/c.bas
@@ -746,6 +746,7 @@ private sub cGccAttribute(byref gccattribs as integer)
 	     "format_arg", _
 	     "gcc_struct", _
 	     "gnu_inline", _
+	     "leaf", _
 	     "malloc", _
 	     "may_alias", _
 	     "no_instrument_function", _

--- a/cpp.bas
+++ b/cpp.bas
@@ -2555,6 +2555,10 @@ private sub cppDefine(byref flags as integer)
 	definfo->xeol = xeol
 	definfo->macro = macro
 
+	if frog.verbose >= 2 then
+		print "#define " + *macro->text + " " + tkSpell(xbody, xeol)
+	end if
+
 	'' Report conflicting #defines
 	var prevdef = cppLookupMacro(macro->text)
 	if prevdef then
@@ -2584,6 +2588,10 @@ private sub cppUndef(byref flags as integer)
 	end if
 	var id = tkSpellId(cpp.x)
 	cpp.x += 1
+
+	if frog.verbose >= 2 then
+		print "#undef " + *id
+	end if
 
 	cppAddKnownUndefined(id)
 

--- a/fbfrog.bas
+++ b/fbfrog.bas
@@ -824,6 +824,7 @@ end sub
 
 private sub hParseArgs(byref x as integer)
 	static nestinglevel as integer
+	static seentarget as integer
 
 	nestinglevel += 1
 
@@ -862,10 +863,16 @@ private sub hParseArgs(byref x as integer)
 			frogAddPattern(*tkGetText(x), -1)
 			x += 1
 
-		'' -target (<target>)+
+		'' (-target <target>)+
 		case OPT_TARGET
-			frogSetTargets(FALSE)
 			x += 1
+			'' All OSes and archs default to enabled; disable all the first time
+			'' we see -target so that multiple targets can be selected.
+			'' (However, '-target linux-x86 -target win64' also enables win32 and linux-x86_64)
+			if seentarget = FALSE then
+				frogSetTargets(FALSE)
+				seentarget = TRUE
+			end if
 
 			hExpectStringOrId(x, "<target> argument")
 			var s = *tkGetText(x)

--- a/fbfrog.bas
+++ b/fbfrog.bas
@@ -237,7 +237,7 @@ private sub hPrintHelpAndExit()
 	print "  -dontemit '*.h'       Drop code from matching .h files"
 	print "  -title <package + version> original-license.txt translators.txt [<destination .bi file>]"
 	print "     Add text at the top of .bi file(s): package name + version, copyright, license"
-	print "  -v                    Show verbose/debugging info"
+	print "  -v                    Show verbose/debugging info. Pass -v -v for more debug info"
 	print "  -target nodos|noarm|<os>|<arch>|<os>-<arch>  Specify OS/arch to translate for, instead of all"
 	print "API script logic:"
 	print "  -declareversions <symbol> (<number>)+     Version numbers"
@@ -832,7 +832,7 @@ private sub hParseArgs(byref x as integer)
 		var opt = tkGet(x)
 		select case as const opt
 		case OPT_V
-			frog.verbose = TRUE
+			frog.verbose += 1
 			x += 1
 
 		case OPT_O

--- a/fbfrog.bi
+++ b/fbfrog.bi
@@ -188,6 +188,7 @@ extern osinfo(0 to OS__COUNT-1) as OsInfo
 extern archinfo(0 to ARCH__COUNT-1) as ArchInfo
 
 declare function osParse(byref s as string) as integer
+declare function archParse(byref s as string) as integer
 
 type TargetInfo
 	as byte os, arch

--- a/readme.txt
+++ b/readme.txt
@@ -63,10 +63,10 @@ What's this?
      there's always something missing...)
 
   fbfrog preprocesses and parses the input headers multiple times: once for each
-  supported target (DOS/Linux/Windows, x86/x86_64) and merges all these APIs
-  together into the final binding. If you need to override this (for example if
-  your .h files don't support DOS and have an #error statement for this case),
-  then use -target and specify the needed targets manually.
+  supported target (DOS/Linux/Windows/etc, x86/x86_64/arm/aarch64) and merges
+  all these APIs together into the final binding. If you need to override this
+  (for example if your .h files don't support DOS and have an #error statement
+  for this case), then use -target and specify the needed targets manually.
 
 
 Compiling:

--- a/util.bas
+++ b/util.bas
@@ -711,6 +711,15 @@ function osParse(byref s as string) as integer
 	function = -1
 end function
 
+function archParse(byref s as string) as integer
+	for i as integer = 0 to ARCH__COUNT - 1
+                if *archinfo(i).id = s then
+			return i
+		end if
+	next
+	function = -1
+end function
+
 function TargetInfo.id() as string
 	if (os = OS_DOS) and (arch = ARCH_X86) then
 		return "dos"


### PR DESCRIPTION
Add -target \<arch> and -target \<os>-\<arch>, and -v -v to print out #define's and #undef's as they're encountered.